### PR TITLE
Add GitHub status slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ restore. The `/save` and `/stop` commands create a dated archive and player data
 file which are uploaded via the configured URLs before shutting down (for
 `/stop`). Use `DISCORD_CHANNEL_ID` to restrict the channel and
 `DISCORD_GUILD_ID` to limit registration to a single guild.
+
+The `/githubstatus` command displays the current status of GitHub services.

--- a/commands/githubstatus.js
+++ b/commands/githubstatus.js
@@ -1,0 +1,41 @@
+const { SlashCommandBuilder } = require('discord.js');
+const https = require('https');
+
+function fetchGithubStatus() {
+  return new Promise((resolve, reject) => {
+    https
+      .get('https://www.githubstatus.com/api/v2/status.json', res => {
+        let data = '';
+        res.on('data', chunk => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(data));
+          } catch (err) {
+            reject(err);
+          }
+        });
+      })
+      .on('error', err => reject(err));
+  });
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('githubstatus')
+    .setDescription('Show GitHub service status'),
+  async execute(interaction) {
+    try {
+      const json = await fetchGithubStatus();
+      let body = `GitHub status: ${json.status.indicator} - ${json.status.description}`;
+      const maxBytes = 2000;
+      if (Buffer.byteLength(body, 'utf8') > maxBytes) {
+        body = body.slice(0, maxBytes - 3) + '...';
+      }
+      await interaction.reply(body);
+    } catch (err) {
+      await interaction.reply('Error fetching GitHub status');
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add `/githubstatus` slash command to show GitHub service status
- update documentation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6879433d8c808326a93f34b3479d5ae1