### PR TITLE
Fix message size limit and condense status output

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const fs = require('fs');
 const { Client, GatewayIntentBits, Events } = require('discord.js');
+const { sendReply, sendFollowUp } = require('./lib');
 const path = require('path');
 
 const channelId = process.env.DISCORD_CHANNEL_ID;
@@ -45,10 +46,11 @@ bot.on(Events.InteractionCreate, async interaction => {
     await command.execute(interaction);
   } catch (err) {
     console.error(err);
+    const msg = 'Error: ' + err.message;
     if (interaction.replied || interaction.deferred) {
-      await interaction.followUp({ content: 'Error: ' + err.message, ephemeral: true });
+      await sendFollowUp(interaction, msg, { ephemeral: true });
     } else {
-      await interaction.reply({ content: 'Error: ' + err.message, ephemeral: true });
+      await sendReply(interaction, msg, { ephemeral: true });
     }
   }
 });

--- a/commands/list.js
+++ b/commands/list.js
@@ -1,11 +1,11 @@
 const { SlashCommandBuilder } = require('discord.js');
-const { listBackups, formatBackupTree } = require('../lib');
+const { listBackups, formatBackupTree, sendReply } = require('../lib');
 
 module.exports = {
   data: new SlashCommandBuilder().setName('list').setDescription('List available backups'),
   async execute(interaction) {
     const objects = await listBackups();
     const out = formatBackupTree(objects);
-    await interaction.reply(out || 'No backups');
+    await sendReply(interaction, out || 'No backups');
   }
 };

--- a/commands/save.js
+++ b/commands/save.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const { ec2, findRunningInstance, sshExec, backupCommands, CreateTagsCommand } = require('../lib');
+const { ec2, findRunningInstance, sshExec, backupCommands, CreateTagsCommand, sendReply, sendFollowUp } = require('../lib');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -18,16 +18,16 @@ module.exports = {
   async execute(interaction) {
     const inst = await findRunningInstance();
     if (!inst) {
-      await interaction.reply('No running server');
+      await sendReply(interaction, 'No running server');
       return;
     }
     const name = interaction.options.getString('name');
     const ip = inst.PublicIpAddress;
     await ec2.send(new CreateTagsCommand({ Resources: [inst.InstanceId], Tags: [{ Key: 'SaveName', Value: name }] }));
-    await interaction.reply(`Saving as ${name}...`);
+    await sendReply(interaction, `Saving as ${name}...`);
     if (ip) {
       await sshExec(ip, backupCommands(name));
     }
-    await interaction.followUp('Save complete');
+    await sendFollowUp(interaction, 'Save complete');
   }
 };

--- a/commands/start.js
+++ b/commands/start.js
@@ -15,23 +15,23 @@ module.exports = {
     await interaction.respond(filtered.map(n => ({ name: n, value: n })));
   },
   async execute(interaction) {
-    await interaction.reply('Checking for existing server...');
+    await lib.sendReply(interaction, 'Checking for existing server...');
     const existing = await lib.findRunningInstance();
     if (existing) {
-      await interaction.followUp('Server already running');
+      await lib.sendFollowUp(interaction, 'Server already running');
       return;
     }
     const saveLabel = interaction.options.getString('name');
-    await interaction.followUp('Launching EC2 instance...');
+    await lib.sendFollowUp(interaction, 'Launching EC2 instance...');
     const sgId = await lib.ensureSecurityGroup();
     const id = await lib.launchInstance(sgId, saveLabel);
     lib.state.instanceId = id;
     const ip = await lib.waitForInstance(id);
     const backupFile = saveLabel ? await lib.getLatestBackupFile(saveLabel) : null;
-    await interaction.followUp(
+    await lib.sendFollowUp(
       `Instance launched with IP ${ip}${backupFile ? ', restoring backup...' : ', installing docker...'}`
     );
     await lib.sshAndSetup(ip, backupFile);
-    await interaction.followUp(`Factorio server running at ${ip}`);
+    await lib.sendFollowUp(interaction, `Factorio server running at ${ip}`);
   }
 };

--- a/commands/status.js
+++ b/commands/status.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const { template, findRunningInstance, getSystemStats, formatMetadata } = require('../lib');
+const { template, findRunningInstance, getSystemStats, formatMetadata, sendReply } = require('../lib');
 
 module.exports = {
   data: new SlashCommandBuilder().setName('status').setDescription('Get server status'),
@@ -20,9 +20,9 @@ module.exports = {
         'Disk /opt/factorio': stats.disk
       };
       const table = formatMetadata(meta);
-      await interaction.reply(table || 'No data');
+      await sendReply(interaction, table || 'No data');
     } else {
-      await interaction.reply('No running servers');
+      await sendReply(interaction, 'No running servers');
     }
   }
 };

--- a/commands/stop.js
+++ b/commands/stop.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const { ec2, state, findRunningInstance, sshExec, backupCommands, TerminateInstancesCommand, DescribeInstancesCommand } = require('../lib');
+const { ec2, state, findRunningInstance, sshExec, backupCommands, TerminateInstancesCommand, DescribeInstancesCommand, sendReply, sendFollowUp } = require('../lib');
 
 module.exports = {
   data: new SlashCommandBuilder().setName('stop').setDescription('Stop the Factorio server'),
@@ -8,18 +8,18 @@ module.exports = {
       ? (await ec2.send(new DescribeInstancesCommand({ InstanceIds: [state.instanceId] }))).Reservations[0].Instances[0]
       : await findRunningInstance();
     if (!inst) {
-      await interaction.reply('No running server');
+      await sendReply(interaction, 'No running server');
       return;
     }
     const ip = inst.PublicIpAddress;
     const tag = (inst.Tags || []).find(t => t.Key === 'SaveName');
     const name = tag ? tag.Value : `backup-${Date.now()}`;
-    await interaction.reply(`Stopping server and saving as ${name}...`);
+    await sendReply(interaction, `Stopping server and saving as ${name}...`);
     if (ip) {
       await sshExec(ip, backupCommands(name));
     }
     await ec2.send(new TerminateInstancesCommand({ InstanceIds: [inst.InstanceId] }));
     state.instanceId = null;
-    await interaction.followUp('Server terminated');
+    await sendFollowUp(interaction, 'Server terminated');
   }
 };


### PR DESCRIPTION
## Summary
- add helpers to chunk replies so messages stay under 2000 bytes
- streamline `formatMetadata` so the status output is shorter
- update commands to use the new helpers
- wire helpers into error handling

## Testing
- `node -c bot.js && node -c lib.js && for f in commands/*.js; do node -c $f; done`
- `npm install` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6879471b9fec83269d9d948ca2712845