### PR TITLE
Add sync command with push

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,7 @@ The bot uses slash commands which are registered automatically on startup. Use
 `/start` to launch the server, optionally selecting a prior backup name to
 restore. The `/save` and `/stop` commands create a dated archive and player data
 file which are uploaded via the configured URLs before shutting down (for
-`/stop`). Use `DISCORD_CHANNEL_ID` to restrict the channel and
-`DISCORD_GUILD_ID` to limit registration to a single guild.
+`/stop`). The `/sync` command attempts to pull from the configured git remote
+and, if no merge conflicts occur, pushes your local branch. Use
+`DISCORD_CHANNEL_ID` to restrict the channel and `DISCORD_GUILD_ID` to limit
+registration to a single guild.

--- a/commands/sync.js
+++ b/commands/sync.js
@@ -1,0 +1,28 @@
+const { SlashCommandBuilder } = require('discord.js');
+const cp = require('child_process');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('sync')
+    .setDescription('Sync repository with remote'),
+  async execute(interaction) {
+    await interaction.reply('Syncing repository...');
+    cp.exec('git pull --no-edit', (err, stdout, stderr) => {
+      if (err) {
+        interaction.followUp('Pull failed: ' + (stderr || err.message));
+        return;
+      }
+      if (/CONFLICT/.test(stdout) || /CONFLICT/.test(stderr)) {
+        interaction.followUp('Merge conflicts detected. Push aborted.');
+        return;
+      }
+      cp.exec('git push', (err2, stdout2, stderr2) => {
+        if (err2) {
+          interaction.followUp('Push failed: ' + (stderr2 || err2.message));
+        } else {
+          interaction.followUp('Repository synced and pushed.');
+        }
+      });
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- add a `/sync` command that pulls and pushes the repo
- document the new command in the README

## Testing
- `node --check commands/sync.js`
- `for f in $(git ls-files '*.js'); do node --check $f; done`

------
https://chatgpt.com/codex/tasks/task_e_68797da43544832698340c3a19071650