### PR TITLE
Switch backups to use aws s3 cp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,8 @@ BACKUP_BUCKET=factorio-backups
 SSH_KEY_PATH=/path/to/ssh.pem
 EC2_TEMPLATE=ec2_template.json
 DOCKER_IMAGE=factoriotools/factorio:latest
-# No longer required: backups are stored directly in S3
+# No longer required: backups are stored directly in S3.
+# Objects with the same key will be replaced when using `aws s3 cp`.
 
 DEBUG_LOG=0
 # set to 1 to enable console logging

--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,7 @@ BACKUP_BUCKET=factorio-backups
 SSH_KEY_PATH=/path/to/ssh.pem
 EC2_TEMPLATE=ec2_template.json
 DOCKER_IMAGE=factoriotools/factorio:latest
-BACKUP_UPLOAD_URL=https://example.com/upload
-BACKUP_UPLOAD_AUTH_HEADER=Authorization: Bearer token
-BACKUP_DOWNLOAD_URL=https://example.com/download
-BACKUP_DOWNLOAD_AUTH_HEADER=Authorization: Bearer token
+# No longer required: backups are stored directly in S3
+
 DEBUG_LOG=0
 # set to 1 to enable console logging

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ AWS_REGION=us-east-1
 DISCORD_TOKEN=your_discord_token
 DISCORD_CHANNEL_ID=1234567890
 BACKUP_BUCKET=factorio-backups
+# These credentials are passed to AWS CLI commands that run on the EC2 instance
+# to upload and restore backups.
 SSH_KEY_PATH=/path/to/ssh.pem
 EC2_TEMPLATE=ec2_template.json
 DOCKER_IMAGE=factoriotools/factorio:latest

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project contains a simple Discord bot that can manage a Factorio game serve
 4. Ensure `BACKUP_BUCKET` is an accessible S3 bucket. Backups are uploaded and
    restored using `aws s3 cp`. The commands include your `AWS_ACCESS_KEY_ID`
    and `AWS_SECRET_ACCESS_KEY` from `.env` so the remote instance can access the
-   bucket.
+   bucket. Existing objects with the same key are overwritten automatically.
 5. Set `DEBUG_LOG=1` to print time-stamped debugging output to the console. The bot logs major actions and command events when this flag is enabled.
 
 ## Running the Bot
@@ -27,6 +27,6 @@ node bot.js
 The bot uses slash commands which are registered automatically on startup. Use
 `/start` to launch the server, optionally selecting a prior backup name to
 restore. The `/save` and `/stop` commands create a dated archive and player data
-file which are uploaded via the configured URLs before shutting down (for
+file which are uploaded to the configured S3 bucket before shutting down (for
 `/stop`). Use `DISCORD_CHANNEL_ID` to restrict the channel and
 `DISCORD_GUILD_ID` to limit registration to a single guild.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This project contains a simple Discord bot that can manage a Factorio game serve
 3. Set `DOCKER_IMAGE` to the Factorio Docker image you wish to run
    (e.g. `factoriotools/factorio:latest`).
 4. Ensure `BACKUP_BUCKET` is an accessible S3 bucket. Backups are uploaded and
-   restored using `aws s3 cp`.
+   restored using `aws s3 cp`. The commands include your `AWS_ACCESS_KEY_ID`
+   and `AWS_SECRET_ACCESS_KEY` from `.env` so the remote instance can access the
+   bucket.
 5. Set `DEBUG_LOG=1` to print time-stamped debugging output to the console. The bot logs major actions and command events when this flag is enabled.
 
 ## Running the Bot

--- a/README.md
+++ b/README.md
@@ -9,10 +9,8 @@ This project contains a simple Discord bot that can manage a Factorio game serve
    The bot automatically loads variables from `.env` when it starts.
 3. Set `DOCKER_IMAGE` to the Factorio Docker image you wish to run
    (e.g. `factoriotools/factorio:latest`).
-4. Configure `BACKUP_UPLOAD_URL` and `BACKUP_DOWNLOAD_URL` with endpoints that
-   accept authenticated `curl` uploads and downloads. Provide the matching
-   `BACKUP_UPLOAD_AUTH_HEADER` and `BACKUP_DOWNLOAD_AUTH_HEADER` values to
-   include in the requests.
+4. Ensure `BACKUP_BUCKET` is an accessible S3 bucket. Backups are uploaded and
+   restored using `aws s3 cp`.
 5. Set `DEBUG_LOG=1` to print time-stamped debugging output to the console. The bot logs major actions and command events when this flag is enabled.
 
 ## Running the Bot

--- a/lib.js
+++ b/lib.js
@@ -214,7 +214,7 @@ async function sshAndSetup(ip, backupFile) {
       const regionFlag = process.env.AWS_REGION ? ` --region ${process.env.AWS_REGION}` : '';
       const creds = `AWS_ACCESS_KEY_ID=${process.env.AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${process.env.AWS_SECRET_ACCESS_KEY}`;
       cmds.push(
-        `${creds} aws s3 cp s3://${process.env.BACKUP_BUCKET}/${backupFile}${regionFlag} | tar xj -C /opt/factorio`
+        `${creds} aws s3 cp s3://${process.env.BACKUP_BUCKET}/${backupFile} -${regionFlag} | tar xj -C /opt/factorio`
       );
     }
     cmds.push(

--- a/lib.js
+++ b/lib.js
@@ -212,8 +212,9 @@ async function sshAndSetup(ip, backupFile) {
     ];
     if (backupFile) {
       const regionFlag = process.env.AWS_REGION ? ` --region ${process.env.AWS_REGION}` : '';
+      const creds = `AWS_ACCESS_KEY_ID=${process.env.AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${process.env.AWS_SECRET_ACCESS_KEY}`;
       cmds.push(
-        `aws s3 cp s3://${process.env.BACKUP_BUCKET}/${backupFile} -${regionFlag} | tar xj -C /opt/factorio`
+        `${creds} aws s3 cp s3://${process.env.BACKUP_BUCKET}/${backupFile}${regionFlag} | tar xj -C /opt/factorio`
       );
     }
     cmds.push(
@@ -331,12 +332,13 @@ function backupCommands(name) {
   const file = backupFilename(name);
   const jsonFile = `${name}.${currentDateString()}.json`;
   const regionFlag = process.env.AWS_REGION ? ` --region ${process.env.AWS_REGION}` : '';
+  const creds = `AWS_ACCESS_KEY_ID=${process.env.AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${process.env.AWS_SECRET_ACCESS_KEY}`;
   log('Backup command for', name);
   return (
     `sudo docker stop factorio && ` +
     `tar cjf /tmp/${file} -C /opt factorio && ` +
-    `aws s3 cp /opt/factorio/player-data.json s3://${process.env.BACKUP_BUCKET}/${jsonFile}${regionFlag} && ` +
-    `aws s3 cp /tmp/${file} s3://${process.env.BACKUP_BUCKET}/${file}${regionFlag} && ` +
+    `${creds} aws s3 cp /opt/factorio/player-data.json s3://${process.env.BACKUP_BUCKET}/${jsonFile}${regionFlag} && ` +
+    `${creds} aws s3 cp /tmp/${file} s3://${process.env.BACKUP_BUCKET}/${file}${regionFlag} && ` +
     `rm /tmp/${file} && sudo docker start factorio`
   );
 }


### PR DESCRIPTION
## Summary
- copy backup archives directly to S3 using `aws s3 cp`
- fetch archives from S3 during server setup using `aws s3 cp`
- remove unused HTTP upload/download env vars
- document S3 backup usage

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_687ab0cbbc8483269799658a2f256e16