### PR TITLE
Add backup describe command

### DIFF
--- a/commands/describe.js
+++ b/commands/describe.js
@@ -1,0 +1,33 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { listBackups, parseBackupKey, formatMetadata, getBackupJson, sendReply, log } = require('../lib');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('describe')
+    .setDescription('Describe a backup')
+    .addStringOption(o =>
+      o.setName('id').setDescription('Backup name and date').setAutocomplete(true).setRequired(true)
+    ),
+  async autocomplete(interaction) {
+    const focused = interaction.options.getFocused();
+    const objects = await listBackups();
+    const names = new Set();
+    for (const o of objects) {
+      const p = parseBackupKey(o.Key);
+      if (p) names.add(`${p.name}.${p.date}`);
+    }
+    const filtered = Array.from(names)
+      .filter(n => n.startsWith(focused))
+      .slice(0, 25);
+    await interaction.respond(filtered.map(n => ({ name: n, value: n })));
+  },
+  async execute(interaction) {
+    log('describe command invoked');
+    await interaction.deferReply();
+    const id = interaction.options.getString('id');
+    const data = await getBackupJson(id);
+    const out = formatMetadata(data);
+    await sendReply(interaction, out || 'No data');
+    log('describe command completed');
+  }
+};

--- a/commands/start.js
+++ b/commands/start.js
@@ -33,7 +33,7 @@ module.exports = {
     const backupFile = saveLabel ? await lib.getLatestBackupFile(saveLabel) : null;
     await lib.sendFollowUp(
       interaction,
-      `Instance launched with IP ${ip}${backupFile ? ', restoring backup...' : ', installing docker...'}`
+      `Instance launched with IP ${ip}${backupFile ? `, restoring backup ${saveLabel}...` : ', installing docker...'}`
     );
     await lib.sshAndSetup(ip, backupFile);
     await lib.sendFollowUp(interaction, `Factorio server running at ${ip}`);

--- a/lib.js
+++ b/lib.js
@@ -215,7 +215,7 @@ async function sshAndSetup(ip, backupFile) {
       const regionFlag = process.env.AWS_REGION ? ` --region ${process.env.AWS_REGION}` : '';
       const creds = `AWS_ACCESS_KEY_ID=${process.env.AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${process.env.AWS_SECRET_ACCESS_KEY}`;
       cmds.push(
-        `${creds} aws s3 cp s3://${process.env.BACKUP_BUCKET}/${backupFile} -${regionFlag} | tar xj -C /opt/factorio`
+        `${creds} aws s3 cp s3://${process.env.BACKUP_BUCKET}/${backupFile}${regionFlag} - | sudo tar xj -C /opt`
       );
     }
     cmds.push(

--- a/lib.js
+++ b/lib.js
@@ -337,10 +337,11 @@ function backupCommands(name) {
   log('Backup command for', name);
   return (
     `sudo docker stop factorio && ` +
-    `tar cjf /tmp/${file} -C /opt factorio && ` +
+    `sudo rm -rf /tmp/${file} &&` +
+    `sudo tar cjf /tmp/${file} -C /opt factorio &&` +
     `${creds} aws s3 cp /opt/factorio/player-data.json s3://${process.env.BACKUP_BUCKET}/${jsonFile}${regionFlag} && ` +
     `${creds} aws s3 cp /tmp/${file} s3://${process.env.BACKUP_BUCKET}/${file}${regionFlag} && ` +
-    `rm /tmp/${file} && sudo docker start factorio`
+    `sudo rm /tmp/${file} && sudo docker start factorio`
   );
 }
 


### PR DESCRIPTION
## Summary
- fetch backup JSON from S3 via `getBackupJson`
- add helper to read streams
- new `/describe` command to show metadata for a chosen backup

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687acfc583ac83268c0f0239b27db20f