### PR TITLE
feat: add version option to start command

### DIFF
--- a/commands/save.js
+++ b/commands/save.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const { ec2, findRunningInstance, sshExec, backupCommands, CreateTagsCommand, sendReply, sendFollowUp, listBackups, log } = require('../lib');
+const { ec2, findRunningInstance, sshExec, rconSave, backupCommands, CreateTagsCommand, sendReply, sendFollowUp, listBackups, log } = require('../lib');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -28,6 +28,7 @@ module.exports = {
     await ec2.send(new CreateTagsCommand({ Resources: [inst.InstanceId], Tags: [{ Key: 'SaveName', Value: name }] }));
     await sendReply(interaction, `Saving as ${name}...`);
     if (ip) {
+      await rconSave(ip);
       await sshExec(ip, backupCommands(name));
     }
     await sendFollowUp(interaction, 'Save complete');

--- a/commands/save.js
+++ b/commands/save.js
@@ -1,19 +1,39 @@
 const { SlashCommandBuilder } = require('discord.js');
-const { ec2, findRunningInstance, sshExec, rconSave, backupCommands, CreateTagsCommand, sendReply, sendFollowUp, listBackups, log } = require('../lib');
+const {
+  ec2,
+  findRunningInstance,
+  sshExec,
+  rconSave,
+  backupCommands,
+  CreateTagsCommand,
+  sendReply,
+  sendFollowUp,
+  listBackupNames,
+  log
+} = require('../lib');
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('save')
-    .setDescription('Save the server with a name')
-    .addStringOption(o => o.setName('name').setDescription('Save name').setAutocomplete(true).setRequired(true)),
+    .setDescription('Save the server with an optional name')
+    .addStringOption(o =>
+      o
+        .setName('name')
+        .setDescription('Save name')
+        .setAutocomplete(true)
+        .setRequired(false)
+    ),
   async autocomplete(interaction) {
     const focused = interaction.options.getFocused();
-    const backups = await listBackups();
-    const filtered = backups
-      .map(o => o.Key)
-      .filter(b => b.startsWith(focused))
-      .slice(0, 25);
-    await interaction.respond(filtered.map(b => ({ name: b, value: b })));
+    const names = await listBackupNames();
+    const filtered = names
+      .filter(n => n.startsWith(focused))
+      .slice(0, 24);
+    const options = (focused
+      ? [focused, ...filtered.filter(n => n !== focused)]
+      : filtered
+    ).map(n => ({ name: n, value: n })).slice(0, 25);
+    await interaction.respond(options);
   },
   async execute(interaction) {
     log('save command invoked');
@@ -23,10 +43,16 @@ module.exports = {
       await sendReply(interaction, 'No running server');
       return;
     }
-    const name = interaction.options.getString('name');
+    const inputName = interaction.options.getString('name');
+    const tag = (inst.Tags || []).find(t => t.Key === 'SaveName');
+    const name = inputName || (tag ? tag.Value : `backup-${Date.now()}`);
     const ip = inst.PublicIpAddress;
-    await ec2.send(new CreateTagsCommand({ Resources: [inst.InstanceId], Tags: [{ Key: 'SaveName', Value: name }] }));
-    await sendReply(interaction, `Saving as ${name}...`);
+    if (inputName) {
+      await ec2.send(
+        new CreateTagsCommand({ Resources: [inst.InstanceId], Tags: [{ Key: 'SaveName', Value: inputName }] })
+      );
+    }
+    await sendReply(interaction, `Saving as \`${name}\`...`);
     if (ip) {
       await rconSave(ip);
       await sshExec(ip, backupCommands(name));

--- a/commands/start.js
+++ b/commands/start.js
@@ -59,10 +59,10 @@ module.exports = {
       : null;
     await lib.sendFollowUp(
       interaction,
-      `Instance launched with IP ${ip}${backupFile ? `, restoring backup ${backup}...` : ', installing docker...'}`
+      `Instance launched with IP \`${ip}\`${backupFile ? `, restoring backup \`${backup}\`...` : ', installing docker...'}`
     );
     await lib.sshAndSetup(ip, backupFile, version);
-    await lib.sendFollowUp(interaction, `Factorio server running at ${ip}`);
+    await lib.sendFollowUp(interaction, `Factorio server running at \`${ip}\``);
     log('start command completed');
   }
 };

--- a/commands/stop.js
+++ b/commands/stop.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const { ec2, state, findRunningInstance, sshExec, backupCommands, TerminateInstancesCommand, DescribeInstancesCommand, sendReply, sendFollowUp, log } = require('../lib');
+const { ec2, state, findRunningInstance, sshExec, rconSave, backupCommands, TerminateInstancesCommand, DescribeInstancesCommand, sendReply, sendFollowUp, log } = require('../lib');
 
 module.exports = {
   data: new SlashCommandBuilder().setName('stop').setDescription('Stop the Factorio server'),
@@ -18,6 +18,7 @@ module.exports = {
     const name = tag ? tag.Value : `backup-${Date.now()}`;
     await sendReply(interaction, `Stopping server and saving as ${name}...`);
     if (ip) {
+      await rconSave(ip);
       await sshExec(ip, backupCommands(name));
     }
     await ec2.send(new TerminateInstancesCommand({ InstanceIds: [inst.InstanceId] }));

--- a/lib.js
+++ b/lib.js
@@ -198,11 +198,20 @@ function connectSSH(ip, attempts = 10) {
   });
 }
 
-async function sshAndSetup(ip, backupFile) {
-  log('Setting up instance', ip, backupFile ? 'with backup '+backupFile : '');
+async function sshAndSetup(ip, backupFile, version) {
+  log(
+    'Setting up instance',
+    ip,
+    backupFile ? 'with backup ' + backupFile : '',
+    version ? 'version ' + version : ''
+  );
   const ssh = await connectSSH(ip);
   return new Promise((resolve, reject) => {
-    const image = process.env.DOCKER_IMAGE || 'factoriotools/factorio:latest';
+    const baseImage = process.env.DOCKER_IMAGE || 'factoriotools/factorio:latest';
+    const lastColon = baseImage.lastIndexOf(':');
+    const repo = lastColon === -1 ? baseImage : baseImage.slice(0, lastColon);
+    const defaultTag = lastColon === -1 ? 'latest' : baseImage.slice(lastColon + 1);
+    const image = `${repo}:${version || defaultTag}`;
     const ports = (template.ingress_ports || [])
       .map(p => `-p ${p}:${p}/udp`)
       .join(' ');

--- a/lib.js
+++ b/lib.js
@@ -376,8 +376,13 @@ function backupCommands(name) {
   const regionFlag = process.env.AWS_REGION ? ` --region ${process.env.AWS_REGION}` : '';
   const creds = `AWS_ACCESS_KEY_ID=${process.env.AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${process.env.AWS_SECRET_ACCESS_KEY}`;
   log('Backup command for', name);
+  const rconSave = [
+    'RCON_PORT=$(sudo docker exec factorio printenv RCON_PORT)',
+    'RCON_PASSWORD=$(sudo docker exec factorio printenv RCON_PASSWORD)',
+    'sudo docker run --rm --network container:factorio -e RCON_PORT -e RCON_PASSWORD factoriotools/factorio /opt/factorio/bin/rcon-cli /save'
+  ].join(' && ');
   return (
-    `sudo docker exec factorio /opt/factorio/bin/rcon-cli /save && ` +
+    `${rconSave} && ` +
     `sudo docker stop factorio && ` +
     `sudo rm -rf /tmp/${file} &&` +
     `sudo tar cjf /tmp/${file} -C /opt factorio &&` +

--- a/lib.js
+++ b/lib.js
@@ -377,6 +377,7 @@ function backupCommands(name) {
   const creds = `AWS_ACCESS_KEY_ID=${process.env.AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${process.env.AWS_SECRET_ACCESS_KEY}`;
   log('Backup command for', name);
   return (
+    `sudo docker exec factorio /opt/factorio/bin/rcon-cli /save && ` +
     `sudo docker stop factorio && ` +
     `sudo rm -rf /tmp/${file} &&` +
     `sudo tar cjf /tmp/${file} -C /opt factorio &&` +

--- a/rcon.js
+++ b/rcon.js
@@ -1,0 +1,37 @@
+const net = require('net');
+
+function encode(id, type, body) {
+  const bodyBuf = Buffer.from(body, 'utf8');
+  const len = bodyBuf.length + 10;
+  const buf = Buffer.alloc(len + 4);
+  buf.writeInt32LE(len, 0);
+  buf.writeInt32LE(id, 4);
+  buf.writeInt32LE(type, 8);
+  bodyBuf.copy(buf, 12);
+  buf.writeInt16LE(0, 12 + bodyBuf.length);
+  return buf;
+}
+
+async function sendRcon(host, port, password, command) {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host, port }, () => {
+      socket.write(encode(1, 3, password));
+    });
+    let authenticated = false;
+    socket.on('data', data => {
+      if (!authenticated) {
+        authenticated = true;
+        socket.write(encode(2, 2, command));
+      } else {
+        socket.end();
+        resolve(data.toString('utf8', 12, data.length - 2));
+      }
+    });
+    socket.on('error', err => {
+      socket.end();
+      reject(err);
+    });
+  });
+}
+
+module.exports = { sendRcon };


### PR DESCRIPTION
## Summary
- allow `/start` to run a specific Factorio version
- autocomplete `/start` backup names with full timestamps

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688c9319eb608326bb8ecd291cefb8c9