### PR TITLE
Configure EC2 instance with swap file

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -209,7 +209,12 @@ async function sshAndSetup(ip, backupFile) {
     const cmds = [
       'sudo yum install -y docker',
       'sudo service docker start',
-      'sudo mkdir -p /opt/factorio'
+      'sudo mkdir -p /opt/factorio',
+      'sudo dd if=/dev/zero of=/swapfile bs=1M count=1024',
+      'sudo chmod 600 /swapfile',
+      'sudo mkswap /swapfile',
+      'sudo swapon /swapfile',
+      'echo "/swapfile none swap sw 0 0" | sudo tee -a /etc/fstab'
     ];
     if (backupFile) {
       const regionFlag = process.env.AWS_REGION ? ` --region ${process.env.AWS_REGION}` : '';


### PR DESCRIPTION
## Summary
- create 1GB swap on EC2 host during setup

## Testing
- `npm test` *(fails: missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6899fb19307883269b602d0336ffdfe0