### PR TITLE
feat: add version option to start command

### DIFF
--- a/commands/start.js
+++ b/commands/start.js
@@ -7,13 +7,32 @@ module.exports = {
     .setName('start')
     .setDescription('Start the Factorio server')
     .addStringOption(o =>
-      o.setName('name').setDescription('Optional save label').setRequired(false).setAutocomplete(true)
+      o
+        .setName('name')
+        .setDescription('Optional backup key (name.date)')
+        .setRequired(false)
+        .setAutocomplete(true)
+    )
+    .addStringOption(o =>
+      o
+        .setName('version')
+        .setDescription('Optional Factorio version tag')
+        .setRequired(false)
     ),
   async autocomplete(interaction) {
     const focused = interaction.options.getFocused();
-    const names = await lib.listBackupNames();
-    const filtered = names.filter(n => n.startsWith(focused)).slice(0, 25);
-    await interaction.respond(filtered.map(n => ({ name: n, value: n })));
+    const backups = await lib.listBackups();
+    const filtered = backups
+      .map(o => o.Key)
+      .filter(k => k.startsWith(focused))
+      .slice(0, 25);
+    await interaction.respond(
+      filtered.map(k => {
+        const p = lib.parseBackupKey(k);
+        const name = p ? `${p.name}.${p.date}` : k;
+        return { name, value: k };
+      })
+    );
   },
   async execute(interaction) {
     log('start command invoked');
@@ -24,19 +43,26 @@ module.exports = {
       await lib.sendFollowUp(interaction, 'Server already running');
       return;
     }
-    const saveLabel = interaction.options.getString('name');
+    const backup = interaction.options.getString('name');
+    const version = interaction.options.getString('version');
     await lib.sendFollowUp(interaction, 'Launching EC2 instance...');
     const sgId = await lib.ensureSecurityGroup();
+    const parsed = backup ? lib.parseBackupKey(backup) : null;
+    const saveLabel = parsed ? parsed.name : backup;
     const id = await lib.launchInstance(sgId, saveLabel);
     lib.state.instanceId = id;
     const ip = await lib.waitForInstance(id);
-    const backupFile = saveLabel ? await lib.getLatestBackupFile(saveLabel) : null;
+    const backupFile = backup
+      ? backup.endsWith('.tar.bz2')
+        ? backup
+        : await lib.getLatestBackupFile(backup)
+      : null;
     await lib.sendFollowUp(
       interaction,
-      `Instance launched with IP ${ip}${backupFile ? `, restoring backup ${saveLabel}...` : ', installing docker...'}`
+      `Instance launched with IP \`${ip}\`${backupFile ? `, restoring backup \`${backup}\`...` : ', installing docker...'}`
     );
-    await lib.sshAndSetup(ip, backupFile);
-    await lib.sendFollowUp(interaction, `Factorio server running at ${ip}`);
+    await lib.sshAndSetup(ip, backupFile, version);
+    await lib.sendFollowUp(interaction, `Factorio server running at \`${ip}\``);
     log('start command completed');
   }
 };

--- a/lib.js
+++ b/lib.js
@@ -24,7 +24,13 @@ const { Client: SSHClient } = require('ssh2');
 function log(...args) {
   if (process.env.DEBUG_LOG === '1' || process.env.DEBUG_LOG === 'true') {
     const ts = new Date().toISOString();
-    console.log(ts, ...args);
+    const fmt = args.map(a => {
+      if (typeof a === 'string' && !a.startsWith('`') && !a.endsWith('`') && !a.includes(' ')) {
+        return `\`${a}\``;
+      }
+      return a;
+    });
+    console.log(ts, ...fmt);
   }
 }
 
@@ -198,11 +204,20 @@ function connectSSH(ip, attempts = 10) {
   });
 }
 
-async function sshAndSetup(ip, backupFile) {
-  log('Setting up instance', ip, backupFile ? 'with backup '+backupFile : '');
+async function sshAndSetup(ip, backupFile, version) {
+  log(
+    'Setting up instance',
+    ip,
+    backupFile ? 'with backup ' + backupFile : '',
+    version ? 'version ' + version : ''
+  );
   const ssh = await connectSSH(ip);
   return new Promise((resolve, reject) => {
-    const image = process.env.DOCKER_IMAGE || 'factoriotools/factorio:latest';
+    const baseImage = process.env.DOCKER_IMAGE || 'factoriotools/factorio:latest';
+    const lastColon = baseImage.lastIndexOf(':');
+    const repo = lastColon === -1 ? baseImage : baseImage.slice(0, lastColon);
+    const defaultTag = lastColon === -1 ? 'latest' : baseImage.slice(lastColon + 1);
+    const image = `${repo}:${version || defaultTag}`;
     const ports = (template.ingress_ports || [])
       .map(p => `-p ${p}:${p}/udp`)
       .join(' ');
@@ -291,7 +306,8 @@ async function listBackups() {
     const resp = await s3.send(
       new ListObjectsV2Command({ Bucket: process.env.BACKUP_BUCKET })
     );
-    return resp.Contents || [];
+    const list = resp.Contents || [];
+    return list.filter(o => !o.Key.endsWith('.json'));
   } catch (err) {
     if (err.Code === 'PermanentRedirect') {
       const region = err.BucketRegion || err.Region;
@@ -310,7 +326,8 @@ async function listBackups() {
       const resp = await s3.send(
         new ListObjectsV2Command({ Bucket: process.env.BACKUP_BUCKET })
       );
-      return resp.Contents || [];
+      const list = resp.Contents || [];
+      return list.filter(o => !o.Key.endsWith('.json'));
     }
     throw err;
   }
@@ -359,7 +376,13 @@ function backupCommands(name) {
   const regionFlag = process.env.AWS_REGION ? ` --region ${process.env.AWS_REGION}` : '';
   const creds = `AWS_ACCESS_KEY_ID=${process.env.AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${process.env.AWS_SECRET_ACCESS_KEY}`;
   log('Backup command for', name);
+  const rconSave = [
+    'RCON_PORT=$(sudo docker exec factorio printenv RCON_PORT)',
+    'RCON_PASSWORD=$(sudo docker exec factorio printenv RCON_PASSWORD)',
+    'sudo docker run --rm --network container:factorio -e RCON_HOST=127.0.0.1 -e RCON_PORT -e RCON_PASSWORD -e RCON_CMD=/save itzg/rcon'
+  ].join(' && ');
   return (
+    `${rconSave} && ` +
     `sudo docker stop factorio && ` +
     `sudo rm -rf /tmp/${file} &&` +
     `sudo tar cjf /tmp/${file} -C /opt factorio &&` +


### PR DESCRIPTION
## Summary
- allow `/start` to run a specific Factorio version
- autocomplete `/start` backup names with full timestamps
- filter out `.json` files when listing backups
- wrap names and IP addresses in backticks in logs
- trigger an RCON save using the `itzg/rcon` Docker image before stopping the Factorio container

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688c9319eb608326bb8ecd291cefb8c9