### PR TITLE
refactor: move setup cmds to AWS strategy

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -205,7 +205,7 @@ function connectSSH(ip, attempts = 10) {
   });
 }
 
-async function sshAndSetup(ip, backupFile, version) {
+async function sshAndSetup(ip, backupFile, version, initCmds: string[] = []) {
   log(
     'Setting up instance',
     ip,
@@ -222,16 +222,7 @@ async function sshAndSetup(ip, backupFile, version) {
     const ports = (template.ingress_ports || [])
       .map(p => `-p ${p}:${p}/udp`)
       .join(' ');
-    const cmds = [
-      'sudo yum install -y docker',
-      'sudo service docker start',
-      'sudo mkdir -p /opt/factorio',
-      'sudo dd if=/dev/zero of=/swapfile bs=1M count=2048',
-      'sudo chmod 600 /swapfile',
-      'sudo mkswap /swapfile',
-      'sudo swapon /swapfile',
-      'echo "/swapfile none swap sw 0 0" | sudo tee -a /etc/fstab'
-    ];
+    const cmds = [...initCmds];
     if (backupFile) {
       const regionFlag = process.env.AWS_REGION ? ` --region ${process.env.AWS_REGION}` : '';
       const creds = `AWS_ACCESS_KEY_ID=${process.env.AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${process.env.AWS_SECRET_ACCESS_KEY}`;

--- a/strategies/AwsProviderStrategy.ts
+++ b/strategies/AwsProviderStrategy.ts
@@ -55,7 +55,17 @@ export class AwsProviderStrategy implements ProviderStrategy {
         backupFile ? `, restoring backup \`${backup}\`...` : ', installing docker...'
       }`
     );
-    await sshAndSetup(ec2Ip, backupFile, version || undefined);
+    const cmds = [
+      'sudo yum install -y docker',
+      'sudo service docker start',
+      'sudo mkdir -p /opt/factorio',
+      'sudo dd if=/dev/zero of=/swapfile bs=1M count=2048',
+      'sudo chmod 600 /swapfile',
+      'sudo mkswap /swapfile',
+      'sudo swapon /swapfile',
+      'echo "/swapfile none swap sw 0 0" | sudo tee -a /etc/fstab'
+    ];
+    await sshAndSetup(ec2Ip, backupFile, version || undefined, cmds);
     await sendFollowUp(interaction, `Factorio server running at \`${ec2Ip}\``);
   }
 

--- a/strategies/AwsProviderStrategy.ts
+++ b/strategies/AwsProviderStrategy.ts
@@ -107,7 +107,7 @@ export class AwsProviderStrategy implements ProviderStrategy {
         'Open Ports': (template.ingress_ports || []).join(', '),
         Load: (stats as any).load,
         Memory: (stats as any).memory,
-        'Disk /opt/factorio': (stats as any).disk,
+        'Disk factorio data': (stats as any).disk,
       };
       const table = formatMetadata(meta);
       await sendReply(interaction, table || 'No data');

--- a/strategies/AwsProviderStrategy.ts
+++ b/strategies/AwsProviderStrategy.ts
@@ -58,7 +58,6 @@ export class AwsProviderStrategy implements ProviderStrategy {
     const cmds = [
       'sudo yum install -y docker',
       'sudo service docker start',
-      'sudo mkdir -p /opt/factorio',
       'sudo dd if=/dev/zero of=/swapfile bs=1M count=2048',
       'sudo chmod 600 /swapfile',
       'sudo mkswap /swapfile',

--- a/strategies/BareMetalProviderStrategy.ts
+++ b/strategies/BareMetalProviderStrategy.ts
@@ -1,6 +1,6 @@
 import { ChatInputCommandInteraction } from 'discord.js';
 import { ProviderStrategy } from './ProviderStrategy';
-import { sshExec, sshAndSetup, sendReply, sendFollowUp, rconSave, backupCommands, getSystemStats, formatMetadata, getLatestBackupFile, log } from '../lib';
+import { sshExec, sshAndSetup, sendReply, sendFollowUp, rconSave, backupCommands, getSystemStats, formatMetadata, getLatestBackupFile, log, state } from '../lib';
 
 export class BareMetalProviderStrategy implements ProviderStrategy {
   constructor(private ip: string) {}
@@ -34,7 +34,7 @@ export class BareMetalProviderStrategy implements ProviderStrategy {
     const name = `backup-${Date.now()}`;
     await sendReply(interaction, `Stopping server and saving as ${name}...`);
     await rconSave(this.ip);
-    await sshExec(this.ip, `${backupCommands(name)} && sudo docker stop factorio`);
+    await sshExec(this.ip, `${backupCommands(name)} && sudo docker stop ${state.containerName}`);
     await sendFollowUp(interaction, 'Server stopped');
   }
 

--- a/strategies/BareMetalProviderStrategy.ts
+++ b/strategies/BareMetalProviderStrategy.ts
@@ -44,7 +44,7 @@ export class BareMetalProviderStrategy implements ProviderStrategy {
       'IP Address': this.ip,
       Load: stats.load,
       Memory: stats.memory,
-      'Disk /opt/factorio': stats.disk,
+      'Disk factorio data': stats.disk,
     };
     const table = formatMetadata(meta);
     await sendReply(interaction, table || 'No data');


### PR DESCRIPTION
## Summary
- Allow sshAndSetup to accept initial command sequences
- Execute EC2 provisioning commands within AwsProviderStrategy

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tsc)*
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b1afb1cc2483268fe7d37162bddf6b